### PR TITLE
Bump versions for two of our dependencies

### DIFF
--- a/zenoss_client.gemspec
+++ b/zenoss_client.gemspec
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+
 lib = File.expand_path('lib/', __FILE__)
 $:.unshift lib unless $:.include?(lib)
 require 'date'
@@ -30,8 +31,8 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 1.8.7'
   gem.add_runtime_dependency  'httpclient', '~> 2.0'
-  gem.add_runtime_dependency  'tzinfo', '~> 0.3.20'
-  gem.add_runtime_dependency  'json', '~> 1.5'
+  gem.add_runtime_dependency  'tzinfo', '~> 2.0.2'
+  gem.add_runtime_dependency  'json', '~> 2.3'
 
   gem.add_development_dependency('rake')
   gem.add_development_dependency('minitest')


### PR DESCRIPTION
This is just so that `zenoss_client` will allow us to use the newer gems without conflict.

The test suite passes all tests with the new versions.

I don't know if this implies a different minimum ruby version than 1.8.7